### PR TITLE
Fix filename in #include directive

### DIFF
--- a/SegmentDisplay_CD4511B.h
+++ b/SegmentDisplay_CD4511B.h
@@ -4,7 +4,7 @@
 #if (ARDUINO >= 100)
   #include "Arduino.h"
 #else
-  #include "WProgram,h"
+  #include "WProgram.h"
 #endif
 
 class SegmentDisplay_CD4511B {


### PR DESCRIPTION
WProgram.h was incorrectly spelled "WProgram,h".

Not sure how many people are still using Wiring or pre-1.0 Arduino IDE, but if it's going to be in the code, it may as well be correct.